### PR TITLE
Feature: Make chatbot able to understand dates and times

### DIFF
--- a/data/beefy.txt
+++ b/data/beefy.txt
@@ -1,1 +1,0 @@
-T,FALSE,sad

--- a/src/main/java/beefy/command/DeadlineCommand.java
+++ b/src/main/java/beefy/command/DeadlineCommand.java
@@ -6,23 +6,40 @@ import beefy.task.Task;
 import beefy.storage.Storage;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class DeadlineCommand implements Command {
     private TaskList userTasks;
-    private String taskDescription, taskBy;
+    private String taskDescription;
+    private LocalDateTime taskBy;
 
     public DeadlineCommand(TaskList userTasks, String userParams) throws BeefyException {
         this.userTasks = userTasks;
         String[] taskDetails = userParams.trim().split("/by");
         if (taskDetails.length < 2) {
-            throw new BeefyException("Use format:" + System.lineSeparator() + "deadline (Task Description) /by (Date)");
+            throw new BeefyException("Use format:" + System.lineSeparator()
+                    + "deadline (Task Description) /by (DateTime)" + System.lineSeparator()
+                    + "E.g: " + System.lineSeparator()
+                    + "deadline Learn how to use deadline command /by "
+                    + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")));
+
         }
         taskDescription = taskDetails[0].trim();
-        taskBy = taskDetails[1].trim();
+        try {
+            taskBy = LocalDateTime.parse(taskDetails[1].trim());
+        } catch (DateTimeParseException e) {
+            throw new BeefyException("Use format: " + System.lineSeparator()
+                    + "deadline (Task Description) /by (DateTime)" + System.lineSeparator()
+                    + "E.g: " + System.lineSeparator()
+                    + "deadline Learn how to use deadline command /by "
+                    + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")));
+        }
     }
 
     @Override
-    public void execute() throws IOException {
+    public void execute() throws IOException, BeefyException {
         Task addedTask = userTasks.addTask(taskDescription, taskBy, false);
         Storage.addToDisk(addedTask.toDiskFormat());
     }

--- a/src/main/java/beefy/command/EventCommand.java
+++ b/src/main/java/beefy/command/EventCommand.java
@@ -4,23 +4,42 @@ import beefy.BeefyException;
 import beefy.storage.Storage;
 import beefy.task.TaskList;
 import beefy.task.Task;
+import java.time.LocalDateTime;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class EventCommand implements Command {
     private TaskList userTasks;
-    private String taskDescription, taskFrom, taskTo;
+    private String taskDescription;
+    private LocalDateTime taskFrom, taskTo;
 
     public EventCommand(TaskList userTasks, String userParams) throws BeefyException {
         this.userTasks = userTasks;
         String[] taskDetails = userParams.trim().split("/from|/to");
         if (taskDetails.length < 3) {
+            LocalDateTime currDateTime = LocalDateTime.now();
             throw new BeefyException("Use format:" + System.lineSeparator()
-                    + "event (Task Description) /from (Date) /to (Date)");
+                    + "event (Task Description) /from (DateTime) /to (DateTime)" + System.lineSeparator()
+                    + "E.g: " + System.lineSeparator()
+                    + "event Learn how to use event command /from "
+                    + currDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")) + " /to "
+                    + currDateTime.plusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")));
         }
         taskDescription = taskDetails[0].trim();
-        taskFrom = taskDetails[1].trim();
-        taskTo = taskDetails[2].trim();
+        try {
+            taskFrom = LocalDateTime.parse(taskDetails[1].trim());
+            taskTo = LocalDateTime.parse(taskDetails[2].trim());
+        } catch (DateTimeParseException e) {
+            LocalDateTime currDateTime = LocalDateTime.now();
+            throw new BeefyException("Use format: " + System.lineSeparator()
+                    + "event (Task Description) /from (DateTime) /to (DateTime)" + System.lineSeparator()
+                    + "E.g: " + System.lineSeparator()
+                    + "event Learn how to use event command /from "
+                    + currDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")) + " /to "
+                    + currDateTime.plusHours(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")));
+        }
     }
 
     @Override

--- a/src/main/java/beefy/storage/Storage.java
+++ b/src/main/java/beefy/storage/Storage.java
@@ -5,6 +5,7 @@ import beefy.BeefyException;
 import beefy.task.*;
 import beefy.ui.Ui;
 
+import java.time.LocalDateTime;
 import java.util.Scanner;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
@@ -31,14 +32,15 @@ public class Storage {
                     }
                     break;
                 case "D":
-                    userTasks.addTask(currParams[2], currParams[3], true);
+                    userTasks.addTask(currParams[2], LocalDateTime.parse(currParams[3]), true);
                     numOfTasks++;
                     if (currParams[1].equals("TRUE")) {
                         userTasks.markTask(numOfTasks, true);
                     }
                     break;
                 case "E":
-                    userTasks.addTask(currParams[2], currParams[3], currParams[4], true);
+                    userTasks.addTask(currParams[2], LocalDateTime.parse(currParams[3]),
+                            LocalDateTime.parse(currParams[4]), true);
                     numOfTasks++;
                     if (currParams[1].equals("TRUE")) {
                         userTasks.markTask(numOfTasks, true);
@@ -55,10 +57,10 @@ public class Storage {
     }
 
     public static void createFolder() throws IOException {
-            Ui.printMessage("Creating Storage file...");
-            File f = new File(FILE_PATH);
-            f.getParentFile().mkdirs();
-            f.createNewFile();
+        Ui.printMessage("Creating Storage file...");
+        File f = new File(FILE_PATH);
+        f.getParentFile().mkdirs();
+        f.createNewFile();
     }
 
     public static void updateDisk(TaskList taskList) throws IOException {

--- a/src/main/java/beefy/task/Deadline.java
+++ b/src/main/java/beefy/task/Deadline.java
@@ -1,10 +1,15 @@
 package beefy.task;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class Deadline extends Task{
+    protected LocalDateTime byDate;
     protected String by;
-    public Deadline(String description, String by) {
+    public Deadline(String description, LocalDateTime by) {
         super(description);
-        this.by = by;
+        this.byDate = by;
+        this.by = byDate.format(DateTimeFormatter.ofPattern("MMM d yyyy ',' HHmm"));
     }
 
     public String getBy() {
@@ -19,6 +24,6 @@ public class Deadline extends Task{
     @Override
     public String toDiskFormat() {
         return "D," + (this.getStatus() ? "TRUE," : "FALSE,") + description + ","
-                + by + "\n";
+                + byDate + "\n";
     }
 }

--- a/src/main/java/beefy/task/Event.java
+++ b/src/main/java/beefy/task/Event.java
@@ -1,13 +1,20 @@
 package beefy.task;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class Event extends Task{
+    protected LocalDateTime fromDate;
+    protected LocalDateTime toDate;
     protected String from;
     protected String to;
 
-    public Event(String description, String from, String to) {
+    public Event(String description, LocalDateTime from, LocalDateTime to) {
         super(description);
-        this.from = from;
-        this.to = to;
+        this.fromDate = from;
+        this.toDate = to;
+        this.from = from.format(DateTimeFormatter.ofPattern("MMM d yyyy',' HHmm"));
+        this.to = to.format(DateTimeFormatter.ofPattern("MMM d yyyy',' HHmm"));
     }
 
     public String getFrom() {
@@ -26,7 +33,7 @@ public class Event extends Task{
     @Override
     public String toDiskFormat() {
         return "E," + (this.getStatus() ? "TRUE," : "FALSE,") + description + ","
-                + from + ","
-                + to + "\n";
+                + fromDate + ","
+                + toDate + "\n";
     }
 }

--- a/src/main/java/beefy/task/TaskList.java
+++ b/src/main/java/beefy/task/TaskList.java
@@ -1,6 +1,7 @@
 package beefy.task;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import beefy.BeefyException;
@@ -39,8 +40,8 @@ public class TaskList {
         return userTask;
     }
 
-    public Task addTask(String taskDescription, String by, boolean isInitialize) {
-        Deadline userTask = new Deadline(taskDescription, by);
+    public Task addTask(String taskDescription, LocalDateTime by, boolean isInitialize) {
+        beefy.task.Deadline userTask = new beefy.task.Deadline(taskDescription, by);
         tasks.add(userTask);
         numberOfTasks++;
         if (!isInitialize) {
@@ -50,8 +51,8 @@ public class TaskList {
         return userTask;
     }
 
-    public Task addTask(String taskDescription, String from, String to, boolean isInitialize) {
-        Event userTask = new Event(taskDescription, from, to);
+    public Task addTask(String taskDescription, LocalDateTime from, LocalDateTime to, boolean isInitialize) {
+        beefy.task.Event userTask = new beefy.task.Event(taskDescription, from, to);
         tasks.add(userTask);
         numberOfTasks++;
         if (!isInitialize) {
@@ -72,16 +73,16 @@ public class TaskList {
     }
 
     public void markTask(int taskId, boolean isInitialize) throws BeefyException {
-            Task selectedTask = tasks.get(taskId - 1);
-            if (selectedTask.getStatus()) {
-                throw new BeefyException("Are you blind mate?");
-            } else {
-                selectedTask.setMark();
-                if (isInitialize) {
-                    Ui.printMessage("Nice one mate! I've marked this task as done:" + System.lineSeparator()
-                            + selectedTask);
-                }
+        Task selectedTask = tasks.get(taskId - 1);
+        if (selectedTask.getStatus()) {
+            throw new BeefyException("Are you blind mate?");
+        } else {
+            selectedTask.setMark();
+            if (isInitialize) {
+                Ui.printMessage("Nice one mate! I've marked this task as done:" + System.lineSeparator()
+                        + selectedTask);
             }
+        }
     }
 
     public void unmarkTask(int taskId, boolean isInitialize) throws BeefyException {


### PR DESCRIPTION
Chatbot can accept any string input for commands deadline and event.

Allowing chatbot to only accept a specific dateTime format for the dateTime inputs will ensure proper deadline and event duration are being stored. This ensures clean data storage.

Let's
* Refactor Deadline and Event class to store dateTime information in a variable of type LocalDateTime
* Refactor DeadlineCommand and EventCommand constructors to throw an exception when deadline's/event's dateTime information is not keyed in using the proper dateTime format
* Refactor readDisk function in Storage class to parse dateTime information stored in csv file into a LocalDateTime variable